### PR TITLE
Revise security policy for version support and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions. 
+We encourage all users of these service layers to update to the latest version for the best experience.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
+| < 3.3   | :x:                |
+
+## Reporting a Vulnerability
+
+Thank you for letting us know about possible security vulnerabilities to this project. 
+Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
+
+Your message will recieve a prompt reply. 


### PR DESCRIPTION
Updated the security policy to clarify version support and reporting process. Previously it did not have one.